### PR TITLE
Enable direct Battle Map page

### DIFF
--- a/assets/alpine.min.js
+++ b/assets/alpine.min.js
@@ -1,1 +1,0 @@
-// Alpine.js placeholder

--- a/conversio-battle-map.php
+++ b/conversio-battle-map.php
@@ -60,6 +60,19 @@ function cbm_render_map() {
 }
 add_shortcode( 'battle_map', 'cbm_render_map' );
 
+// Rewrite rule and template loader for direct map access.
+add_action( 'init', function () {
+    add_rewrite_rule( '^battle-map/map/?$', 'index.php?battle_map_page=1', 'top' );
+    add_rewrite_tag( '%battle_map_page%', '1' );
+} );
+
+add_filter( 'template_include', function ( $template ) {
+    if ( get_query_var( 'battle_map_page' ) == 1 ) {
+        return plugin_dir_path( __FILE__ ) . 'templates/map-template.php';
+    }
+    return $template;
+} );
+
 // Initialize plugin
 add_action( 'plugins_loaded', function() {
     new CBM_User_Map();

--- a/templates/map-template.php
+++ b/templates/map-template.php
@@ -1,4 +1,51 @@
-<div id="cbm-map" x-data="{}">
+<?php
+$token = isset( $_GET['token'] ) ? sanitize_text_field( $_GET['token'] ) : '';
+?>
+<script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+<div id="cbm-map" x-data="battleMap()" x-init="fetchData()">
     <h2>Battle Map Conversio</h2>
-    <!-- Map placeholder -->
+    <svg viewBox="0 0 800 200" width="100%" height="auto">
+      <template x-if="mapData">
+        <template x-for="(section, index) in mapData.userMap.territories[0].sections" :key="section.slug">
+          <g :transform="`translate(${100 + index * 200}, 100)`">
+            <circle
+              r="40"
+              :fill="section.completed ? '#4ade80' : (section.unlocked ? '#facc15' : '#94a3b8')"
+              stroke="#1e293b"
+              stroke-width="3"
+            ></circle>
+            <text
+              x="0"
+              y="5"
+              font-size="14"
+              fill="#1e293b"
+              text-anchor="middle"
+              x-text="section.slug"
+            ></text>
+          </g>
+        </template>
+      </template>
+    </svg>
 </div>
+
+<script>
+function battleMap() {
+    return {
+        mapData: null,
+        async fetchData() {
+            const token = '<?php echo esc_js( $token ); ?>';
+            if (!token) {
+                return;
+            }
+            try {
+                const res = await fetch('/wp-json/battle-map/v1/user?token=' + token);
+                if (res.ok) {
+                    this.mapData = await res.json();
+                }
+            } catch (e) {
+                console.error(e);
+            }
+        }
+    }
+}
+</script>


### PR DESCRIPTION
## Summary
- add rewrite rule to serve `/battle-map/map` from plugin
- load plugin template when `battle_map_page` query var is present
- fetch map data and render map sections as circles with Alpine.js
- load Alpine.js from CDN and remove unused local file

## Testing
- `npm test` *(fails: could not find `package.json`)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431b4a2c68832992f89293f5f6f0e5