### PR TITLE
Add gamified scoring

### DIFF
--- a/includes/class-rest-endpoints.php
+++ b/includes/class-rest-endpoints.php
@@ -386,5 +386,24 @@ class CBM_Rest_Endpoints {
         return $pdf;
     }
 
-    // The calculate_points method was replaced by the global calculatePoints helper.
+// The calculate_points method was replaced by the global calculatePoints helper.
 }
+
+add_action( 'rest_api_init', function() {
+    register_rest_route(
+        'conversio-battle-map/v1',
+        '/map/token/(?P<access_token>[a-zA-Z0-9_-]+)',
+        [
+            'methods'             => 'GET',
+            'callback'            => function( WP_REST_Request $request ) {
+                $token = $request['access_token'];
+                $data  = CBM_User_Map::get_user_map_by_token( $token );
+                if ( $data ) {
+                    return wp_send_json_success( $data );
+                }
+                return wp_send_json_error( [ 'message' => 'Mapa no encontrado.' ], 404 );
+            },
+            'permission_callback' => '__return_true',
+        ]
+    );
+} );

--- a/includes/class-user-map.php
+++ b/includes/class-user-map.php
@@ -60,4 +60,97 @@ class CBM_User_Map {
             'achievements'   => $achievements,
         ];
     }
+
+    public static function get_user_map_by_token( $token ) {
+        $token = sanitize_text_field( $token );
+
+        $args = [
+            'post_type'      => 'battle_map',
+            'posts_per_page' => 1,
+            'fields'         => 'ids',
+            'meta_query'     => [
+                [
+                    'key'   => 'access_token',
+                    'value' => $token,
+                ],
+            ],
+        ];
+
+        $posts = get_posts( $args );
+        if ( empty( $posts ) ) {
+            return null;
+        }
+
+        $post = get_post( $posts[0] );
+        if ( ! $post ) {
+            return null;
+        }
+
+        return self::build_user_map_data( $post );
+    }
+
+    public static function get_user_map_by_user_id( $user_id ) {
+        $user_id = sanitize_text_field( $user_id );
+
+        $args = [
+            'post_type'      => 'battle_map',
+            'posts_per_page' => 1,
+            'fields'         => 'ids',
+            'meta_query'     => [
+                [
+                    'key'   => 'user_id',
+                    'value' => $user_id,
+                ],
+            ],
+        ];
+
+        $posts = get_posts( $args );
+        if ( empty( $posts ) ) {
+            return null;
+        }
+
+        $post = get_post( $posts[0] );
+        if ( ! $post ) {
+            return null;
+        }
+
+        return self::build_user_map_data( $post );
+    }
+
+    private static function build_user_map_data( $post ) {
+        $user_map_json     = get_post_meta( $post->ID, 'user_map', true );
+        $progress_json     = get_post_meta( $post->ID, 'progress_record', true );
+        $achievements_json = get_post_meta( $post->ID, 'achievements', true );
+
+        if ( ! $user_map_json || ! $progress_json || ! $achievements_json ) {
+            return null;
+        }
+
+        $user_map = json_decode( $user_map_json, true );
+        if ( json_last_error() !== JSON_ERROR_NONE ) {
+            return null;
+        }
+
+        $progress = json_decode( $progress_json, true );
+        if ( json_last_error() !== JSON_ERROR_NONE ) {
+            return null;
+        }
+
+        $achievements = json_decode( $achievements_json, true );
+        if ( json_last_error() !== JSON_ERROR_NONE ) {
+            return null;
+        }
+
+        return [
+            'userMap'        => $user_map,
+            'progressRecord' => $progress,
+            'achievements'   => $achievements,
+        ];
+    }
+
+    public static function update_user_map_data( $post_id, $user_map, $progress_record = [], $achievements = [] ) {
+        update_post_meta( $post_id, 'user_map', wp_json_encode( $user_map ) );
+        update_post_meta( $post_id, 'progress_record', wp_json_encode( $progress_record ) );
+        update_post_meta( $post_id, 'achievements', wp_json_encode( $achievements ) );
+    }
 }

--- a/includes/register-cpt.php
+++ b/includes/register-cpt.php
@@ -1,11 +1,14 @@
 <?php
 function register_battle_map_cpt() {
     $args = [
-        'label'           => 'Battle Maps',
+        'labels'          => [
+            'name'          => 'Battle Maps',
+            'singular_name' => 'Battle Map',
+        ],
         'public'          => false,
         'show_ui'         => true,
-        'show_in_rest'    => false,
-        'supports'        => ['title'],
+        'show_in_rest'    => true,
+        'supports'        => [ 'title', 'custom-fields' ],
         'capability_type' => 'post',
         'menu_position'   => 25,
         'menu_icon'       => 'dashicons-location-alt',
@@ -14,3 +17,47 @@ function register_battle_map_cpt() {
     register_post_type( 'battle_map', $args );
 }
 add_action( 'init', 'register_battle_map_cpt' );
+
+/**
+ * Initialize default meta fields when a Battle Map post is created.
+ *
+ * @param int     $post_id Post ID.
+ * @param WP_Post $post    Post object.
+ * @param bool    $update  Whether this is an existing post being updated.
+ */
+function cbm_initialize_battle_map_fields( $post_id, $post, $update ) {
+    // Only on creation, avoid autosaves.
+    if ( $update || defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+        return;
+    }
+
+    $token = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( '', true );
+    $user_id = $post->post_author ? $post->post_author : get_current_user_id();
+
+    // Basic template with Clarity Call territory unlocked.
+    $user_map = [
+        'currentTerritorySlug' => 'clarity-call',
+        'territories'          => [
+            [
+                'slug'      => 'clarity-call',
+                'title'     => 'Clarity Call\u2122',
+                'unlocked'  => true,
+                'completed' => false,
+                'order'     => 1,
+                'sections'  => [
+                    [ 'slug' => 'home', 'completed' => false, 'unlocked' => true ],
+                    [ 'slug' => 'product', 'completed' => false, 'unlocked' => false ],
+                    [ 'slug' => 'cart', 'completed' => false, 'unlocked' => false ],
+                    [ 'slug' => 'checkout', 'completed' => false, 'unlocked' => false ],
+                ],
+            ],
+        ],
+    ];
+
+    update_post_meta( $post_id, 'access_token', $token );
+    update_post_meta( $post_id, 'user_id', $user_id );
+    update_post_meta( $post_id, 'user_map', wp_json_encode( $user_map ) );
+    update_post_meta( $post_id, 'progress_record', wp_json_encode( [] ) );
+    update_post_meta( $post_id, 'achievements', wp_json_encode( [] ) );
+}
+add_action( 'save_post_battle_map', 'cbm_initialize_battle_map_fields', 10, 3 );

--- a/templates/map-template.php
+++ b/templates/map-template.php
@@ -33,20 +33,44 @@
     }
   </style>
 </head>
-<body x-data="demoMap()">
+<body x-data="demoMap()" x-init="init()" style="position: relative;">
 
   <h2>Battle Map Conversio</h2>
 
-  <div style="margin: 1rem 0;">
-    Primer nodo: <strong x-text="mapData.userMap.territories[0].sections[0].slug"></strong>
+  <div style="position:absolute; top:20px; right:20px; background:#ffffff; padding:0.5rem 1rem; border-radius:4px; box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+    Progreso: <span x-text="`${mapData.totalPoints} / 1000 puntos`"></span>
+  </div>
+
+  <button @click="showAchievementsPanel = true" style="position:absolute; top:20px; left:20px; background:#1e293b; color:#fff; padding:0.25rem 0.5rem; border-radius:4px;">Logros</button>
+
+  <div x-show="mapData.userMap && mapData.userMap.currentTerritorySlug" style="margin-bottom:1rem;">
+    <h3 x-text="getCurrentTerritoryTitle()"></h3>
+    <div style="height:8px; background:#e2e8f0; border-radius:4px; overflow:hidden;">
+      <div style="height:100%; background:#4ade80;" :style="`width:${getTerritoryProgress().percent}%`"></div>
+    </div>
+    <div style="font-size:12px; margin-top:4px;" x-text="`${getTerritoryProgress().completed} de ${getTerritoryProgress().total} secciones completadas`"></div>
   </div>
 
   <template x-if="mapData && mapData.userMap && mapData.userMap.territories.length > 0">
     <svg viewBox="0 0 800 200" width="100%" height="200" style="background: #f1f5f9;">
+      <template x-if="mapData.visualMap && Array.isArray(mapData.visualMap.paths)">
+        <g>
+          <template x-for="(path, i) in mapData.visualMap.paths" :key="i">
+            <path
+              :d="buildPathD(path)"
+              stroke="#94a3b8"
+              stroke-width="2"
+              fill="none"
+              :stroke-dasharray="path.dashed ? '4 4' : ''"
+            ></path>
+          </template>
+        </g>
+      </template>
       <g
         x-for="(section, index) in mapData.userMap.territories[0].sections"
         :key="section.slug"
-        :transform="`translate(${100 + index * 200}, 100)`"
+        :transform="getNodeTransform(section.slug, index)"
+        @click="showPopup(section.slug, $event)"
       >
         <circle
           r="40"
@@ -66,6 +90,54 @@
     </svg>
   </template>
 
+  <template x-if="popupBox.visible">
+    <div
+      class="popup-box"
+      :style="`position:absolute; left:${popupBox.position.x}px; top:${popupBox.position.y}px; transform:translate(-50%, 10px); background:#fff; box-shadow:0 2px 8px rgba(0,0,0,0.3); padding:1rem; border-radius:8px; width:220px;`">
+      <h3 x-text="popupBox.title" style="margin-top:0; font-size:16px;"></h3>
+      <p>
+        Estado:
+        <span x-text="(() => { const sec = popupBox.targetSlug ? mapData.userMap.territories.flatMap(t => t.sections).find(s => s.slug === popupBox.targetSlug) : null; return sec && sec.completed ? 'completada' : (sec && sec.unlocked ? 'desbloqueada' : 'bloqueada'); })()"></span>
+      </p>
+      <p x-show="popupBox.friction">Fricción: <span x-text="popupBox.friction"></span></p>
+      <p x-show="popupBox.recommendation">Recomendación: <span x-text="popupBox.recommendation"></span></p>
+      <p x-show="popupBox.details" x-text="popupBox.details"></p>
+      <button @click="popupBox.visible = false" style="margin-top:0.5rem;">Cerrar</button>
+    </div>
+  </template>
+
+  <template x-if="territoryCompletedBox.visible">
+    <div style="position:fixed; bottom:20px; left:50%; transform:translateX(-50%); background:#ffffff; box-shadow:0 4px 12px rgba(0,0,0,0.3); padding:1rem 1.5rem; border-radius:8px; max-width:420px; text-align:center; z-index:1000;">
+      <h3 x-text="territoryCompletedBox.title" style="margin-top:0;"></h3>
+      <p x-text="territoryCompletedBox.message" style="margin-bottom:1rem;"></p>
+      <a :href="territoryCompletedBox.ctaLink" style="display:inline-block; padding:0.5rem 1rem; background:#2563eb; color:#fff; border-radius:4px; text-decoration:none;" x-text="territoryCompletedBox.ctaLabel"></a>
+      <button @click="territoryCompletedBox.visible = false" style="display:block; margin-top:0.5rem;">Cerrar</button>
+    </div>
+  </template>
+
+  <template x-if="achievementNotification.visible">
+    <div x-transition.opacity style="position:fixed; top:70px; left:50%; transform:translateX(-50%); background:#ffffff; padding:0.75rem 1rem; box-shadow:0 2px 8px rgba(0,0,0,0.3); border-radius:6px; z-index:1000;">
+      <span x-text="achievementNotification.message"></span>
+    </div>
+  </template>
+
+  <template x-if="showAchievementsPanel">
+    <div style="position:fixed; top:100px; left:50%; transform:translateX(-50%); background:#fff; box-shadow:0 4px 12px rgba(0,0,0,0.3); padding:1rem; border-radius:8px; max-width:300px; z-index:1000;">
+      <h3>Logros</h3>
+      <ul style="list-style:none; padding-left:0;">
+        <template x-for="ach in mapData.achievements" :key="ach.id">
+          <li style="margin-bottom:0.5rem;">
+            <span x-text="ach.title || ach.id"></span>
+            <span x-text="ach.unlocked ? '✅' : '🔒'" style="margin-left:0.25rem;"></span>
+          </li>
+        </template>
+      </ul>
+      <button @click="showAchievementsPanel = false" style="margin-top:0.5rem;">Cerrar</button>
+    </div>
+  </template>
+
+  <div x-show="error" style="color: red; margin-bottom: 1rem;" x-text="error"></div>
+
   <div class="debug">
     <strong>Debug:</strong><br>
     Estado: <span x-text="loading ? 'Cargando...' : (error ? 'Error' : 'OK')"></span><br>
@@ -80,24 +152,245 @@
         loading: false,
         error: false,
         mapData: {
-          userMap: {
-            currentTerritorySlug: 'clarity-call',
-            territories: [
-              {
-                slug: 'clarity-call',
-                title: 'Clarity Call\u2122',
-                unlocked: true,
-                completed: false,
-                order: 1,
-                sections: [
-                  { slug: 'home', completed: true, unlocked: true },
-                  { slug: 'product', completed: false, unlocked: true },
-                  { slug: 'cart', completed: false, unlocked: false },
-                  { slug: 'checkout', completed: false, unlocked: false }
-                ]
-              }
-            ]
+          userMap: {},
+          progressRecord: {},
+          achievements: [],
+          totalPoints: 0,
+          mapSettings: {
+            enableSoundFx: false
           }
+        },
+        popupBox: {
+          title: '',
+          friction: '',
+          recommendation: '',
+          details: '',
+          visible: false,
+          targetSlug: '',
+          position: { x: 0, y: 0 }
+        },
+        territoryCompletedBox: {
+          visible: false,
+          title: '',
+          message: '',
+          ctaLabel: '',
+          ctaLink: ''
+        },
+        achievementNotification: {
+          visible: false,
+          message: ''
+        },
+        showAchievementsPanel: false,
+        init() {
+          const token = new URLSearchParams(window.location.search).get('token');
+          if (!token) {
+            this.error = 'Token no encontrado.';
+            return;
+          }
+          this.loading = true;
+          fetch(`/wp-json/conversio-battle-map/v1/map/token/${token}`)
+            .then(r => r.json())
+            .then(response => {
+              if (response.success === true) {
+                this.mapData.userMap = response.data.userMap;
+                this.mapData.progressRecord = response.data.progressRecord;
+                this.mapData.achievements = response.data.achievements;
+                this.error = false;
+                this.calculatePoints();
+                this.checkTerritoryCompletion();
+              } else {
+                this.error = response.data && response.data.message ? response.data.message : 'Error al cargar el mapa.';
+              }
+            })
+            .catch(() => {
+              this.error = 'Error al cargar el mapa.';
+            })
+            .finally(() => {
+              this.loading = false;
+            });
+        },
+        showPopup(slug, evt) {
+          if (!this.mapData.userMap || !Array.isArray(this.mapData.userMap.territories)) {
+            return;
+          }
+          let sectionInfo = null;
+          for (const territory of this.mapData.userMap.territories) {
+            if (!Array.isArray(territory.sections)) continue;
+            for (const sec of territory.sections) {
+              if (sec.slug === slug) {
+                sectionInfo = sec;
+                break;
+              }
+            }
+            if (sectionInfo) break;
+          }
+          if (!sectionInfo) {
+            return;
+          }
+          this.popupBox.title = sectionInfo.title || slug;
+          this.popupBox.friction = sectionInfo.friction || '';
+          this.popupBox.recommendation = sectionInfo.recommendation || '';
+          this.popupBox.details = sectionInfo.details || '';
+          this.popupBox.targetSlug = slug;
+          const rect = evt.currentTarget.getBoundingClientRect();
+          this.popupBox.position.x = rect.left + rect.width / 2 + window.scrollX;
+          this.popupBox.position.y = rect.top + rect.height + window.scrollY;
+          this.popupBox.visible = true;
+        },
+        getCurrentTerritory() {
+          if (!this.mapData.userMap || !Array.isArray(this.mapData.userMap.territories)) {
+            return null;
+          }
+          return this.mapData.userMap.territories.find(t => t.slug === this.mapData.userMap.currentTerritorySlug) || null;
+        },
+        getCurrentTerritoryTitle() {
+          const terr = this.getCurrentTerritory();
+          return terr ? (terr.title || terr.slug) : '';
+        },
+        getTerritoryProgress() {
+          const terr = this.getCurrentTerritory();
+          if (!terr || !Array.isArray(terr.sections)) {
+            return { completed: 0, total: 0, percent: 0 };
+          }
+          const total = terr.sections.length;
+          const completed = terr.sections.filter(s => s.completed).length;
+          const percent = total ? Math.round((completed / total) * 100) : 0;
+          return { completed, total, percent };
+        },
+        checkTerritoryCompletion() {
+          const terr = this.getCurrentTerritory();
+          if (!terr || !Array.isArray(terr.sections)) {
+            return;
+          }
+          const allDone = terr.sections.every(s => s.completed);
+          if (allDone) {
+            this.territoryCompletedBox.title = terr.title || terr.slug;
+            this.territoryCompletedBox.message =
+              '¡Felicidades! Has completado este territorio. Sigue avanzando al siguiente reto!';
+            this.territoryCompletedBox.ctaLabel = 'Descubre el siguiente territorio';
+            this.territoryCompletedBox.ctaLink = '#';
+            this.territoryCompletedBox.visible = true;
+          }
+          this.calculatePoints();
+        },
+        calculatePoints() {
+          if (!this.mapData.userMap || !Array.isArray(this.mapData.userMap.territories)) {
+            this.mapData.totalPoints = 0;
+            return;
+          }
+          const multipliers = { None: 0, Low: 1, Medium: 1.2, High: 1.5, Critical: 2 };
+          let completedWeight = 0;
+          let totalWeight = 0;
+          for (const terr of this.mapData.userMap.territories) {
+            if (!terr.unlocked || !Array.isArray(terr.sections)) continue;
+            for (const sec of terr.sections) {
+              const friction = sec.friction || 'None';
+              const impact = parseFloat(sec.impact) || 0;
+              const weight = impact * (multipliers[friction] ?? 0);
+              if (sec.completed) completedWeight += weight;
+              totalWeight += weight;
+            }
+          }
+          if (totalWeight > 0) {
+            this.mapData.totalPoints = Math.floor((completedWeight / totalWeight) * 1000);
+          } else {
+            this.mapData.totalPoints = 0;
+          }
+          this.unlockAchievements();
+        },
+        unlockAchievements() {
+          const catalog = [
+            {
+              id: 'first-step',
+              title: 'Primer paso \uD83C\uDF31',
+              check: () => {
+                if (!this.mapData.userMap || !Array.isArray(this.mapData.userMap.territories)) return false;
+                for (const terr of this.mapData.userMap.territories) {
+                  if (!Array.isArray(terr.sections)) continue;
+                  if (terr.sections.some(s => s.completed)) return true;
+                }
+                return false;
+              }
+            },
+            {
+              id: 'clarity-complete',
+              title: 'Clarity Call completo',
+              check: () => {
+                if (!this.mapData.userMap || !Array.isArray(this.mapData.userMap.territories)) return false;
+                const terr = this.mapData.userMap.territories.find(t => t.slug === 'clarity-call');
+                return terr && Array.isArray(terr.sections) && terr.sections.every(s => s.completed);
+              }
+            },
+            {
+              id: 'half-map',
+              title: 'Mitad del mapa',
+              check: () => this.mapData.totalPoints >= 500
+            },
+            {
+              id: 'full-map',
+              title: 'Mapa completo \uD83C\uDFC6',
+              check: () => this.mapData.totalPoints === 1000
+            }
+          ];
+
+          catalog.forEach(ach => {
+            const existing = this.mapData.achievements.find(a => a.id === ach.id);
+            const unlocked = existing && existing.unlocked;
+            if (!unlocked && ach.check()) {
+              const now = new Date().toISOString();
+              if (existing) {
+                existing.unlocked = true;
+                existing.unlockedAt = now;
+                existing.title = ach.title;
+              } else {
+                this.mapData.achievements.push({ id: ach.id, title: ach.title, unlocked: true, unlockedAt: now });
+              }
+              this.showAchievement(ach.title);
+            }
+          });
+        },
+        showAchievement(title) {
+          this.achievementNotification.message = `\u00A1Logro desbloqueado! ${title}`;
+          this.achievementNotification.visible = true;
+          if (this.mapData.mapSettings && this.mapData.mapSettings.enableSoundFx) {
+            try {
+              const audio = new Audio('/wp-content/plugins/conversio-battle-map/assets/success.mp3');
+              audio.play();
+            } catch (e) {}
+            if (navigator.vibrate) navigator.vibrate(200);
+          }
+          setTimeout(() => { this.achievementNotification.visible = false; }, 3000);
+        },
+        getNodePosition(slug) {
+          if (this.mapData.visualMap && Array.isArray(this.mapData.visualMap.nodes)) {
+            const node = this.mapData.visualMap.nodes.find(n => n.slug === slug);
+            if (node) return { x: parseFloat(node.x), y: parseFloat(node.y) };
+          }
+          if (this.mapData.userMap && this.mapData.userMap.territories && this.mapData.userMap.territories[0]) {
+            const idx = this.mapData.userMap.territories[0].sections.findIndex(s => s.slug === slug);
+            if (idx >= 0) {
+              return { x: 100 + idx * 200, y: 100 };
+            }
+          }
+          return null;
+        },
+        getNodeTransform(slug, index) {
+          const pos = this.getNodePosition(slug);
+          if (pos) {
+            return `translate(${pos.x}, ${pos.y})`;
+          }
+          return `translate(${100 + index * 200}, 100)`;
+        },
+        buildPathD(path) {
+          const from = this.getNodePosition(path.fromSlug);
+          const to = this.getNodePosition(path.toSlug);
+          if (!from || !to) return '';
+          if (path.pathType === 'curve') {
+            const cx = (from.x + to.x) / 2;
+            const cy = Math.min(from.y, to.y) - 40;
+            return `M ${from.x} ${from.y} C ${cx} ${cy}, ${cx} ${cy}, ${to.x} ${to.y}`;
+          }
+          return `M ${from.x} ${from.y} L ${to.x} ${to.y}`;
         }
       }
     }


### PR DESCRIPTION
## Summary
- show current points in a floating box
- store `totalPoints` in `mapData`
- calculate score based on completed sections
- integrate achievements unlocking and notification UI

## Testing
- `php -l templates/map-template.php` *(fails: `php` not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6843386a2e10832990290e4761c63144