### PR TITLE
Handle rewrite rules on activation

### DIFF
--- a/conversio-battle-map.php
+++ b/conversio-battle-map.php
@@ -26,6 +26,8 @@ define( 'CBM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
  * Activate plugin: register CPT and flush rewrite rules.
  */
 function cbm_activate() {
+    add_rewrite_rule( '^battle-map/map/?$', 'index.php?battle_map_page=1', 'top' );
+    add_rewrite_tag( '%battle_map_page%', '1' );
     register_battle_map_cpt();
     flush_rewrite_rules();
 }
@@ -61,10 +63,6 @@ function cbm_render_map() {
 add_shortcode( 'battle_map', 'cbm_render_map' );
 
 // Rewrite rule and template loader for direct map access.
-add_action( 'init', function () {
-    add_rewrite_rule( '^battle-map/map/?$', 'index.php?battle_map_page=1', 'top' );
-    add_rewrite_tag( '%battle_map_page%', '1' );
-} );
 
 add_filter( 'template_include', function ( $template ) {
     if ( get_query_var( 'battle_map_page' ) == 1 ) {


### PR DESCRIPTION
## Summary
- move rewrite rule and tag registration into `cbm_activate`
- remove runtime `init` hook for the rewrite rule

## Testing
- `php -l conversio-battle-map.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443c82375c8329bfebdd03ff4871c0