### PR TITLE
Fix map template route and restore admin menu

### DIFF
--- a/conversio-battle-map.php
+++ b/conversio-battle-map.php
@@ -24,8 +24,8 @@ define( 'CBM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 // Custom rewrite rule and tag for direct map access.
 add_action( 'init', function() {
-    add_rewrite_rule( '^battle-map/map/?$', 'index.php?battle_map_page=1', 'top' );
-    add_rewrite_tag( '%battle_map_page%', '1' );
+    add_rewrite_rule( '^battle-map/map/?$', 'index.php?battle_map_view=1', 'top' );
+    add_rewrite_tag( '%battle_map_view%', '1' );
 } );
 
 /**
@@ -69,10 +69,25 @@ add_shortcode( 'battle_map', 'cbm_render_map' );
 // Rewrite rule and template loader for direct map access.
 
 add_filter( 'template_include', function ( $template ) {
-    if ( get_query_var( 'battle_map_page' ) == 1 ) {
+    if ( get_query_var( 'battle_map_view' ) ) {
         return plugin_dir_path( __FILE__ ) . 'templates/map-template.php';
     }
     return $template;
+} );
+
+// Admin menu entry for plugin settings/info
+add_action( 'admin_menu', function() {
+    add_menu_page(
+        'Battle Map',
+        'Battle Map',
+        'manage_options',
+        'conversio-battle-map',
+        function() {
+            echo '<div class="wrap"><h1>Battle Map Conversio</h1><p>Plugin activo y funcionando.</p></div>';
+        },
+        'dashicons-location-alt',
+        56
+    );
 } );
 
 // Initialize plugin


### PR DESCRIPTION
## Summary
- add missing rewrite rule and template loader
- restore Battle Map entry in the admin menu

## Testing
- `php -l conversio-battle-map.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846f83368c883298ba602d3303599e8